### PR TITLE
Allow an array of project keys to send deployment tracking to

### DIFF
--- a/lib/capistrano/tasks/raygun-deployment.cap
+++ b/lib/capistrano/tasks/raygun-deployment.cap
@@ -13,46 +13,50 @@ namespace :deploy do
 		ask(:raygun_auth_token, 'Required')
 	end
 
+    set :raygun_api_key, [fetch(:raygun_api_key)] if !fetch(:raygun_api_key).kind_of?(Array)
+
 	run_locally do
+        fetch(:raygun_api_key).each do |raygun_api_key|
 
-        yaml = YAML::load_file(fetch(:raygun_release_path, 'RELEASE'))
+            yaml = YAML::load_file(fetch(:raygun_release_path, 'RELEASE'))
 
-        use_git = fetch(:scm) == :git && fetch(:use_git, true)
-        git_hash = if use_git && system('git rev-parse --verify HEAD')
-            `git rev-parse --verify HEAD`
-        else
-            ""
+            use_git = fetch(:scm) == :git && fetch(:use_git, true)
+            git_hash = if use_git && system('git rev-parse --verify HEAD')
+                `git rev-parse --verify HEAD`
+            else
+                ""
+            end
+
+            deployment = {
+                'apiKey' => raygun_api_key,
+                'version' => yaml['version'],
+                'ownerName' => yaml['ownerName'],
+                'emailAddress' => yaml['emailAddress'],
+                'comment' => yaml['notes'],
+                'scmIdentifier' => git_hash,
+                'createdAt' => yaml['createdAt']
+            }
+
+    		uri = URI.parse(fetch(:raygun_api_uri, "https://app.raygun.io"))
+    		deploymentEndpoint = "/deployments?authToken=#{fetch(:raygun_auth_token)}"
+
+            http = Net::HTTP.new(uri.host, uri.port)
+            http.use_ssl = fetch(:raygun_use_ssl, true)
+            http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+            request = Net::HTTP::Post.new(deploymentEndpoint)
+            request.add_field('Content-Type', 'application/json')
+            request.body = deployment.to_json
+            res = http.request(request)
+            case res
+            when Net::HTTPSuccess
+              # OK
+                info "Sent deployment to Raygun"
+            else
+                raise "Error sending deployment to Raygun: " + res.value
+            end
         end
-
-        deployment = {
-            'apiKey' => fetch(:raygun_api_key),
-            'version' => yaml['version'],
-            'ownerName' => yaml['ownerName'],
-            'emailAddress' => yaml['emailAddress'],
-            'comment' => yaml['notes'],
-            'scmIdentifier' => git_hash,
-            'createdAt' => yaml['createdAt']
-        }
-
-		uri = URI.parse(fetch(:raygun_api_uri, "https://app.raygun.io"))
-		deploymentEndpoint = "/deployments?authToken=#{fetch(:raygun_auth_token)}"
-
-        http = Net::HTTP.new(uri.host, uri.port)
-        http.use_ssl = fetch(:raygun_use_ssl, true)
-        http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-        request = Net::HTTP::Post.new(deploymentEndpoint)
-        request.add_field('Content-Type', 'application/json')
-        request.body = deployment.to_json
-        res = http.request(request)
-        case res
-        when Net::HTTPSuccess
-          # OK
-            info "Sent deployment to Raygun"
-        else
-            raise "Error sending deployment to Raygun: " + res.value
-        end
+      end
     end
-  end
   after 'deploy:finished', :raygun_register_deployment
 
 end


### PR DESCRIPTION
This PR allows you to send deploy tracking to several projects at once. 
## Use Case
- You have a single repository combining both back end and front end code
- You have two (or more) projects set up in Raygun, one for front end UI and one for backend
